### PR TITLE
Fix for systems that have Python 3

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -116,3 +116,20 @@ case " $CFLAGS " in
   fi
   ;;
 esac])
+
+`# my_CHECK_MAJOR_VERSION(VARIABLE, VERSION, [ACTION-IF-TRUE], [ACTION-IF-FALSE])`  
+`# ---------------------------------------------------------------------------`  
+`# Run ACTION-IF-TRUE if the VAR has a major version >= VERSION.`  
+`# Run ACTION-IF-FALSE otherwise.`  
+AC_DEFUN([my_CHECK_MAJOR_VERSION],  
+[AC_MSG_CHECKING([whether $1 $$1 major version == $2])  
+case $$1 in  
+$2*)  
+  AC_MSG_RESULT([yes])  
+  ifelse([$3], [$3], [:])  
+  ;;  
+*)  
+  AC_MSG_RESULT([no])  
+  ifelse([$4], , [AC_MSG_ERROR([$$1 differs from $2])], [$4])  
+  ;;  
+esac])  

--- a/arg-types.py
+++ b/arg-types.py
@@ -1,4 +1,4 @@
-from codegen.argtypes import ArgType, matcher
+from argtypes import ArgType, matcher
 from codegen import reversewrapper
 
 class CairoMatrixArg(ArgType):

--- a/autogen.sh
+++ b/autogen.sh
@@ -134,6 +134,7 @@ do
 	if test -z "$NO_LIBTOOLIZE" ; then 
 	  echo "Running libtoolize..."
 	  libtoolize --force --copy
+    cp ../../ltmain.sh .     # Fix for Arch, libtoolize puts it in wrong dir.
 	fi
       fi
       echo "Running aclocal $aclocalinclude ..."

--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,11 @@ dnl when using libtool 2.x create libtool early, because it's used in configure
 m4_ifdef([LT_OUTPUT], [LT_OUTPUT]) 
 AM_PROG_CC_C_O
 
+m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
+[ python2 python2.7 python2.6 python2.5 python2.4 python2.3 dnl
+  python2.2 python2.1 python2.0 python])
 AM_PATH_PYTHON(2.2)
+my_CHECK_MAJOR_VERSION([PYTHON_VERSION], [2])
 
 AM_CHECK_PYTHON_HEADERS(,[AC_MSG_ERROR(could not find Python headers)])
 


### PR DESCRIPTION
- **acinclude.m4**: Define a function that throws an error if we are not using Python 2.
- **configure.ac**: Make sure _AM_PYTHON_INTERPRETER_LIST attempts to use all explicit python2 paths before just "python," and never attempts to use any explicit python3 path. Make sure this worked by running the function defined in acinclude.m4
- **arg-types.py**: codegen.argtypes was not found for Python 2.7.13-1. Just using argtypes worked no problem.
- **autogen.sh**: libtoolize will always place the file in the working directory of the interactive environment, which is wherever the user is running the script from. I don't know why it uses this behavior, it seems like it can only cause problems. The file needs to go in the build directory, which is generally the working directory within the script's environment. In manual building, the interactive environment and the script's environment will usually be the same, so this won't be a problem. In that situation, this command returns a file not found error, but it won't interrupt the build process. However, with automatic package building, such as the Arch Build System, libtoolize's behavior is a problem, because usually we are running some other script from a parent directory that ends up calling autogen.sh. This is sort of a hackish fix in that it only fixes the problem when you are running your script from ../.. relative to the build location, but this is a pretty frequent situation that applies at least to all Arch Linux users. This line should not cause any problems, it's just not the best fix.